### PR TITLE
Integrate storage API with data capture. Fixes #42.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
         "mocha": true
     },
     "globals": {
-        "browser": true
+        "browser": true,
+        "store": true
     },
     "plugins": [
         "json",

--- a/js/background.js
+++ b/js/background.js
@@ -4,8 +4,6 @@
 // When the user clicks browserAction icon in toolbar, run Lightbeam
 browser.browserAction.onClicked.addListener(runLightbeam);
 
-capture.init();
-
 async function runLightbeam() {
   // Checks to see if Lightbeam is already open.
   // Returns true if it is, false if not.

--- a/js/capture.js
+++ b/js/capture.js
@@ -1,5 +1,9 @@
-/* eslint no-unused-vars: "off"*/
-/* eslint no-undef: "off" */
+/*
+* Listens for HTTP request responses, sending first- and
+* third-party requests to storage.
+*/
+
+capture.init();
 
 const capture = {
   init() {

--- a/js/capture.js
+++ b/js/capture.js
@@ -1,5 +1,5 @@
-/* eslint no-console: "off" */
-/* eslint no-unused-vars: "off" */
+/* eslint no-unused-vars: "off"*/
+/* eslint no-undef: "off" */
 
 const capture = {
   init() {
@@ -18,31 +18,34 @@ const capture = {
   // capture third party requests
   async sendThirdParty(response) {
     const tab = await browser.tabs.get(response.tabId);
-    const tabUrl = new URL(tab.url);
+    const documentUrl = new URL(tab.url);
     const targetUrl = new URL(response.url);
     const originUrl = new URL(response.originUrl);
 
-    if (targetUrl.hostname !== tabUrl.hostname) {
-      const thirdPartyData = {
-        document: tabUrl.hostname,
+    if (targetUrl.hostname !== documentUrl.hostname) {
+      const data = {
+        document: documentUrl.hostname,
         target: targetUrl.hostname,
         origin: originUrl.hostname,
         requestTime: response.timeStamp
       };
-      console.log('storage.thirdPartyRequest:', tabUrl, thirdPartyData);
+      store.setThirdParty(
+        documentUrl.hostname,
+        targetUrl.hostname,
+        data
+      );
     }
   },
 
   // capture first party requests
   sendFirstParty(tabId, changeInfo, tab) {
-    const tabUrl = new URL(tab.url);
+    const documentUrl = new URL(tab.url);
     // ignore about:* pages and non-visible tabs
     if (tab.status === 'complete'
-      && tabUrl.protocol !== 'about:'
+      && documentUrl.protocol !== 'about:'
       && tabId !== browser.tabs.TAB_ID_NONE) {
-      const firstPartyData = { faviconUrl: tab.favIconUrl };
-      console.log('storage.firstPartyRequest:',
-        tabUrl.hostname, firstPartyData);
+      const data = { faviconUrl: tab.favIconUrl };
+      store.setFirstParty(documentUrl.hostname, data);
     }
   }
 };


### PR DESCRIPTION
Now with calls to storage API instead of `console.log`!
I know I am still overriding some ESLint rules; but I believe they are a consequence of using separate scripts that are bundled. @jonathanKingston: When I tried to use modules (import/export) earlier for the web extension, Firefox didn't recognize the syntax. How can we avoid these manual overrides of ESLint rules?