### PR TITLE
Nit follow ups for layout. Fixes #55.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,7 +28,7 @@
 
 body {
   display: grid;
-  grid-template-columns: 170px auto;
+  grid-template-columns: 170px 1fr;
   height: 100vh;
   margin: 0;
   font-family: "Open Sans", sans-serif;
@@ -265,37 +265,32 @@ main {
   margin-top: -30px;
 }
 
-.website {
-  background-color: transparent;
+.info-panel {
   border-radius: 3px 0 0 3px;
-  margin-top: 0;
+  margin-top: 5px;
+}
+
+.info-panel::before {
+  margin-right: 0;
+}
+
+.info-panel:first-child {
+  background-color: transparent;
   box-shadow: none;
+  margin-top: 0;
 }
 
 .website::before {
   background-image: url('../images/lightbeam_icon_website.png');
-  margin-right: 0;
   opacity: .5;
-}
-
-.help {
-  border-radius: 3px 0 0 3px;
-  margin-top: 5px;
 }
 
 .help::before {
   background-image: url('../images/lightbeam_icon_help.png');
-  margin-right: 0;
-}
-
-.about {
-  border-radius: 3px 0 0 3px;
-  margin-top: 5px;
 }
 
 .about::before {
   background-image: url('../images/lightbeam_icon_about.png');
-  margin-right: 0;
 }
 
 /* ----------- UI - vis Controls ----------- */
@@ -340,6 +335,10 @@ footer div:first-child {
   background-image: url('data:image/svg+xml,<svg version="1.1" xmlns="http://www.w3.org/2000/svg"><line x1="14" y1="2" x2="2" y2="14" style="stroke: rgb(234, 234, 234); stroke-width: 2"></line></svg>');
 }
 
+.two-icons::before {
+  width: 30px;
+}
+
 .watched-sites {
   grid-column-start: 2;
   grid-row-start: 1;
@@ -348,7 +347,6 @@ footer div:first-child {
 
 .watched-sites::before {
   background-image: url('data:image/svg+xml,<svg style="fill: rgb(111, 195, 229)" version="1.1" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="6"></circle></svg>'), url('data:image/svg+xml,<svg style="margin-left: 15px; fill: rgb(111, 195, 229)" version="1.1" xmlns="http://www.w3.org/2000/svg"><polygon points="0,14 7,2 14,14"></polygon></svg>');
-  width: 30px;
 }
 
 .blocked-sites {
@@ -358,7 +356,6 @@ footer div:first-child {
 
 .blocked-sites::before {
   background-image: url('data:image/svg+xml,<svg style="fill: rgb(224, 42, 97)" version="1.1" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="6"></circle></svg>'), url('data:image/svg+xml,<svg style="margin-left: 15px; fill: rgb(224, 42, 97)" version="1.1" xmlns="http://www.w3.org/2000/svg"><polygon points="0,14 7,2 14,14"></polygon></svg>');
-  width: 30px;
 }
 
 .cookies {

--- a/index.html
+++ b/index.html
@@ -16,8 +16,7 @@
   <body>
     <aside>
     <header>
-      <img class="logo" role="banner" src="images/lightbeam_150x45.png
-">
+      <img class="logo" role="banner" src="images/lightbeam_150x45.png">
     </header>
     <nav role="navigation">
       <h2>Visualization</h2>
@@ -83,15 +82,15 @@
             <h2><span id="view">Graph</span> View</h2>
             <!-- @todo display list or graph view, update view based on filter and controls -->
             <!-- @todo remove the hard-coded width, height values -->
-            <canvas id="canvas" width="900" height="300"></canvas>
+            <canvas id="canvas" width="100%" height="100%"></canvas>
           </div>
           <div class="info-panel-controls">
             <!-- @todo check purpose of website icon -->
-            <button class="website"></button>
+            <button class="info-panel website"></button>
             <!-- @todo add help sidebar -->
-            <button class="help"></button>
+            <button class="info-panel help"></button>
             <!-- @todo add about sidebar -->
-            <button class="about"></button>
+            <button class="info-panel about"></button>
           </div>
         </div>
         <footer>
@@ -106,10 +105,10 @@
               <button class="connections active">
                 Connections
               </button>
-              <button class="watched-sites active">
+              <button class="watched-sites two-icons active">
                 Watched Sites
               </button>
-              <button class="blocked-sites active">
+              <button class="blocked-sites two-icons active">
                 Blocked Sites
               </button>
               <button class="cookies active col-3 row-1">


### PR DESCRIPTION
Comments from Issue #55:
Comment 1: Fixed with a new `info-panel` button class.
Comment 2: `.blocked-sites` and `.watched-sites` both have two SVG icons instead of one (unlike any of the other controls buttons. Yes they can share a selector! Added a `two-icons` button class for that.
I use the width to specify the width of the `::before` pseudoelement. In the case of two icons, that space, originally specified in `button::before` for general icon buttons, needs to be increased from 15px to 30px for this case of two icons (each of width 15px). Alternative ideas on this welcome!
Comment 3: Typo fixed!