### PR TITLE
Add structural/layout fixes to top bar. Fixes #56.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -35,7 +35,7 @@ body {
   font-weight: normal; 
 }
 
-h1, h2, h3 {
+h1, h2, h3, dt, dd, label {
   margin: 0;
   font-weight: 400;
 }
@@ -44,16 +44,20 @@ h1 {
   font-size: 1.75em;
 }
 
-h2 {
+h2, dt, label {
   font-size: .75em;
   font-weight: 700;
   text-transform: uppercase;
 }
 
-h3 {
+h3, dd {
   font-size: 1.2em;
   color: var(--secondary-text-color);
   text-transform: uppercase;
+}
+
+var {
+  font-style: normal;
 }
 
 button {
@@ -183,6 +187,7 @@ aside h2 {
 /* ----------- UI - Top Bar ----------- */
 
 main {
+  min-width: 780px;
   display: grid;
   grid-template-rows: 10% 90%;
   background-color: var(--primary-color);
@@ -196,11 +201,11 @@ main {
   padding: 20px;
 }
 
-.top-bar > div {
+.top-bar > dl {
   display: flex;
 }
 
-.top-bar > div > span {
+.top-bar > dl > div {
   margin-right: 15px;
 }
 
@@ -209,7 +214,7 @@ main {
   align-items: center;
 }
 
-.toggle-outer {
+.toggle-switch {
   display: flex;
   align-items: center;
   justify-content: space-around;
@@ -220,14 +225,19 @@ main {
   border-radius: 2px;
 }
 
-.toggle-inner {
+input[type="checkbox"] {
+  -moz-appearance: none;
+  margin: 0;
+}
+
+.toggle {
   height: 20px;
   width: 30px;
   background-color: var(--primary-color);
   border-radius: 5px;
 }
 
-.toggle-label {
+.toggle-status {
   width: 40%;
   font-size: .75em;
   font-weight: 700;

--- a/index.html
+++ b/index.html
@@ -44,32 +44,38 @@
     </aside>
     <main role="main">
       <section class="top-bar">
-        <div>
-          <span>
-            <h2>Data Gathered Since</h2>
-            <!-- @todo get date-start from store -->
-            <h3 id="date-start">June 13, 2017</h3>
-          </span>
-          <span>
-            <h2>You Have Visited</h2>
+        <dl class="info-headings">
+          <div>
+            <dt>Data Gathered Since</dt>
+              <!-- @todo get date-start from store -->
+            <dd id="date-start">
+              <time datetime="2017-06-13T11:00">June 13, 2017</time>
+            </dd>
+          </div>
+          <div>
+            <dt>You Have Visited</dt>
             <!-- @todo get num-sites-visited from store -->
-            <h3><span id="num-sites-visited">6</span> Sites</h3>
-          </span>
-          <span>
-            <h2>You Have Connected With</h2>
+            <dd>
+              <var id="num-sites-visited">6</var> Sites
+            </dd>
+          </div>
+          <div>
+            <dt>You Have Connected With</dt>
             <!-- @todo get num-third-parties from store -->
-            <h3><span id="num-third-parties">16</span> Third Party Sites</h3>
-          </span>
-        </div>
+            <dd>
+              <var id="num-third-parties">16</var> Third Party Sites
+            </dd>
+          </div>
+        </dl>
         <!-- @todo add tracking protection and toggle functionality -->
         <div class="tracking-protection">
-          <h2>Tracking Protection</h2>
-          <div class="toggle-outer">
-            <div class="toggle-inner">
-            </div>
-            <!-- @todo toggle-label to reflect state of tracking protection -->
-            <div class="toggle-label">
-            Off
+          <label for="tracking-protection-control">Tracking Protection</label>
+          <div class="toggle-switch">
+          <!-- @todo couple checkbox status (checked/unchecked) with toggle status -->
+            <input type="checkbox" id="tracking-protection-control">
+            <span class="toggle"></span>
+            <!-- @todo toggle-switch text (off/on) to reflect state of tracking protection -->
+            <span class="toggle-status">Off</span>
             </div>
           </div>
         </div>
@@ -83,7 +89,7 @@
             <h2><span id="view">Graph</span> View</h2>
             <!-- @todo display list or graph view, update view based on filter and controls -->
             <!-- @todo remove the hard-coded width, height values -->
-            <canvas id="canvas" width="900" height="300"></canvas>
+            <canvas id="canvas" width="100%" height="100%"></canvas>
           </div>
           <div class="info-panel-controls">
             <!-- @todo check purpose of website icon -->


### PR DESCRIPTION
- Changed structure of `.top-bar` to use more semantic elements than `<span>`.
- Tracking protection toggle now uses `<input>` and `<label>` elements. Note: still using `<span>` elements for custom appearance. Added a @todo to couple checkbox to custom `<span>` element.
- Added a `min-width` property to `<main>`, so the `.top-bar` text (or content elsewhere in `<main>`) doesn't break. I plan to make a follow-up issue to make UI responsive.