### PR TITLE
Remove moz-extension:* paths from capture. Fixes #49.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,6 @@
 
   "background": {
     "scripts": [
-      "js/store.js",
       "js/capture.js",
       "js/store.js",
       "js/viz.js",


### PR DESCRIPTION
Added a helper function called `shouldStore` to filter out unwanted first- and third-party requests, rather than just first-party only.

Also removed a duplicate `js/store.js` in the `manifest.json` file.