### PR TITLE
Fix for the duplicate store

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "globals": {
         "browser": true,
         "store": true,
+        "storeChild": true,
         "viz": true
     },
     "plugins": [

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="images/lightbeam-48.png" type="image/x-icon">
     <link rel="stylesheet" href="css/style.css" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
-    <script src="js/store.js" type="text/javascript"></script>
+    <script src="js/storeChild.js" type="text/javascript"></script>
     <script src="js/viz.js" type="text/javascript"></script>
   </head>
   <body>

--- a/js/lightbeam.js
+++ b/js/lightbeam.js
@@ -1,8 +1,6 @@
 async function renderGraph() {
   const canvas = document.getElementById('canvas');
   const context = canvas.getContext('2d');
-
-  // eslint-disable-next-line no-undef
   const websites = await storeChild.getAll();
 
   viz.draw(context, websites);

--- a/js/lightbeam.js
+++ b/js/lightbeam.js
@@ -1,7 +1,9 @@
 async function renderGraph() {
   const canvas = document.getElementById('canvas');
   const context = canvas.getContext('2d');
-  const websites = await store.getAll();
+
+  // eslint-disable-next-line no-undef
+  const websites = await storeChild.getAll();
 
   viz.draw(context, websites);
 }

--- a/js/store.js
+++ b/js/store.js
@@ -14,6 +14,18 @@ const store = {
     }
   },
 
+  messageHandler(m) {
+    if (m.type !== 'storeCall') {
+      return;
+    }
+
+    const publicMethods = ['getAll'];
+
+    if (publicMethods.includes(m['method'])) {
+      return this[m['method']](...m.arguments);
+    }
+  },
+
   async _write(websites) {
     this._websites = clone(websites);
 
@@ -88,8 +100,6 @@ const store = {
   }
 };
 
-store.init();
-
 // @todo move this function to utils
 function clone(obj) {
   return Object.assign({}, obj);
@@ -100,16 +110,5 @@ function isObjectEmpty(obj) {
 }
 // @todo end
 
-browser.runtime.onMessage.addListener(messageHandler);
-
-function messageHandler(m) {
-  if (m.type !== 'storeCall') {
-    return;
-  }
-
-  const publicMethods = ['getAll'];
-
-  if (publicMethods.includes(m['method'])) {
-    return store[m['method']](...m.arguments);
-  }
-}
+store.init();
+browser.runtime.onMessage.addListener(store.messageHandler.bind(store));

--- a/js/store.js
+++ b/js/store.js
@@ -111,4 +111,4 @@ function isObjectEmpty(obj) {
 // @todo end
 
 store.init();
-browser.runtime.onMessage.addListener(store.messageHandler.bind(store));
+browser.runtime.onMessage.addListener((m) => store.messageHandler(m));

--- a/js/store.js
+++ b/js/store.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 const store = {
   _websites: null,
 
@@ -81,9 +82,13 @@ const store = {
   },
 
   async remove() {
+    this._websites = null;
+
     return await browser.storage.local.remove('websites');
   }
 };
+
+store.init();
 
 // @todo move this function to utils
 function clone(obj) {
@@ -93,5 +98,18 @@ function clone(obj) {
 function isObjectEmpty(obj) {
   return Object.keys(obj).length === 0;
 }
+// @todo end
 
-store.init();
+browser.runtime.onMessage.addListener(messageHandler);
+
+function messageHandler(m) {
+  if (m.type !== 'storeCall') {
+    return;
+  }
+
+  const publicMethods = ['getAll'];
+
+  if (publicMethods.includes(m['method'])) {
+    return store[m['method']](...m.arguments);
+  }
+}

--- a/js/store.js
+++ b/js/store.js
@@ -3,12 +3,10 @@ const store = {
   _websites: null,
 
   async init() {
-    if (!this._websites || isObjectEmpty(this._websites)) {
+    if (!this._websites) {
       const data = await browser.storage.local.get('websites');
 
-      if (!data.websites) {
-        await this._write({});
-      } else {
+      if (data.websites) {
         this._websites = clone(data.websites);
       }
     }
@@ -103,10 +101,6 @@ const store = {
 // @todo move this function to utils
 function clone(obj) {
   return Object.assign({}, obj);
-}
-
-function isObjectEmpty(obj) {
-  return Object.keys(obj).length === 0;
 }
 // @todo end
 

--- a/js/storeChild.js
+++ b/js/storeChild.js
@@ -1,0 +1,14 @@
+// eslint-disable-next-line no-unused-vars
+const storeChild = {
+  async getAll() {
+    return await this.parentMessage('getAll');
+  },
+
+  parentMessage(method, ...arguments) {
+    return browser.runtime.sendMessage({
+      type: 'storeCall',
+      method,
+      arguments
+    });
+  }
+};

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,6 @@
     "scripts": [
       "js/capture.js",
       "js/store.js",
-      "js/viz.js",
       "js/background.js"
     ]
   }


### PR DESCRIPTION
Issue: #54 

As specified in the issue, we now have a `storeChild.js` which is the entry point for the `lightbeam.js` to talk to the background script `store.js`. Having this setup ensures there is always one `store` instance.