### PR TITLE
POC: d3 force layout with dynamic data

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,11 +1,13 @@
 /* ----------- VISUALIZATION ----------- */
 
-.circle {
-  display: inline-block;
-  width: 100px;
-  height: 100px;
-  border-radius: 50px;
-  background-color: red;
+.links line {
+  stroke: #999;
+  stroke-opacity: 0.6;
+}
+       
+.nodes circle {
+  stroke: #fff;
+  stroke-width: 1.5px;
 }
 
 /* ----------- UI - General ----------- */
@@ -258,6 +260,13 @@ input[type="checkbox"] {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
+  height: 100%;
+}
+
+.vis > div > div {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .vis h1 {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" href="images/lightbeam-48.png" type="image/x-icon">
     <link rel="stylesheet" href="css/style.css" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
-    <script src="js/store.js" type="text/javascript"></script>
+    <script src="node_modules/d3/build/d3.js" type="text/javascript"></script>
     <script src="js/viz.js" type="text/javascript"></script>
   </head>
   <body>
@@ -88,7 +88,7 @@
             <h2><span id="view">Graph</span> View</h2>
             <!-- @todo display list or graph view, update view based on filter and controls -->
             <!-- @todo remove the hard-coded width, height values -->
-            <canvas id="canvas" width="100%" height="100%"></canvas>
+            <svg id="visualization" width="100%" height="100%"></svg>
           </div>
           <div class="info-panel-controls">
             <!-- @todo check purpose of website icon -->

--- a/js/lightbeam.js
+++ b/js/lightbeam.js
@@ -1,9 +1,5 @@
-async function renderGraph() {
-  const canvas = document.getElementById('canvas');
-  const context = canvas.getContext('2d');
-  const websites = await store.getAll();
-
-  viz.draw(context, websites);
+function renderGraph() {
+  viz.draw();
 }
 
-renderGraph();
+window.onload = renderGraph;

--- a/js/viz.js
+++ b/js/viz.js
@@ -1,29 +1,114 @@
 // eslint-disable-next-line no-unused-vars
 const viz = {
-  draw(context, websites) {
-    const pi = Math.PI * 2;
-    let x = 50, y = 50;
+  draw() {
+    const a = { id: 'a' };
+    const b = { id: 'b' };
+    const c = { id: 'c' };
+    const d = { id: 'd' };
+    const e = { id: 'e' };
+    const f = { id: 'f' };
+    const g = { id: 'g' };
+    const h = { id: 'h' };
+    const i = { id: 'i' };
+    const j = { id: 'j' };
+    let nodes = [a, b, c, d, e, f, g, h, i, j];
+    let links = [
+      { source: a, target: b },
+      { source: b, target: c },
+      { source: c, target: d },
+      { source: d, target: e },
+      { source: e, target: f },
+      { source: f, target: g },
+      { source: g, target: h },
+      { source: h, target: i },
+      { source: i, target: j },
+      { source: j, target: a }
+    ];
 
-    context.fillStyle = 'white';
-    context.beginPath();
+    const svg = d3.select('svg');
 
-    for (const website in websites) {
-      context.moveTo(x, y);
-      context.arc(x, y, 10, 0, pi);
-      context.fillText(website, x, y);
+    // D3 needs explicit pixel values for 'center_force'
+    const visualization = document.getElementById('visualization');
+    const width = visualization.getBoundingClientRect().width;
+    const height = visualization.getBoundingClientRect().height;
 
-      let x1 = x;
-      for (const thirdParty in websites[website].thirdPartyRequests) {
-        x1+=150;
-        context.moveTo(x1, y);
-        context.arc(x1, y, 5, 0, pi);
-        context.fillText(thirdParty, x1, y);
-      }
+    const simulation = d3.forceSimulation(nodes)
+      .force('charge', d3.forceManyBody())
+      .force('link', d3.forceLink(links).distance(50))
+      .force('center', d3.forceCenter(width/2, height/2))
+      .alphaTarget(1)
+      .on('tick', ticked);
 
-      x+=20; y+=20;
+    let link = svg.append('g').attr('class', 'links').selectAll('.link');
+    let node = svg.append('g').attr('class', 'nodes').selectAll('.node');
+
+    // initial render
+    update();
+
+    // when data changes, update
+    // this could be from the browser.storage.onchange event for
+    // `websites`
+    d3.interval(function() {
+      const d = { id: 'd'};
+      nodes = [a, b, c, d, e];
+      links = [
+        { source: a, target: b },
+        { source: b, target: c },
+        { source: c, target: d },
+        { source: d, target: e },
+        { source: e, target: a }
+      ];
+      update();
+    }, 2000, d3.now());
+
+    d3.interval(function() {
+      nodes = [a, b, c, d, e, f, g, h, i, j];
+      links = [
+        { source: a, target: b },
+        { source: b, target: c },
+        { source: c, target: d },
+        { source: d, target: e },
+        { source: e, target: f },
+        { source: f, target: g },
+        { source: g, target: h },
+        { source: h, target: i },
+        { source: i, target: j },
+        { source: j, target: a }
+      ];
+      update();
+    }, 2000, d3.now() + 1000);
+
+    function update() {
+      // Apply the general update pattern to the nodes.
+      node = node.data(nodes, function(d) { return d.id; });
+      node.exit().remove();
+      node = node
+        .enter()
+        .append('circle')
+        .attr('fill', 'red')
+        .attr('r', 5)
+        .merge(node);
+
+      // Apply the general update pattern to the links.
+      link = link
+        .data(links, function(d) { return `${d.source.id}-${d.target.id}`;});
+      link.exit().remove();
+      link = link.enter().append('line').merge(link);
+
+      // Update and restart the simulation.
+      simulation.nodes(nodes);
+      simulation.force('link').links(links);
+      simulation.alpha(1).restart();
     }
 
-    context.stroke();
-    context.fill();
+    function ticked() {
+      node.attr('cx', function(d) { return d.x; })
+          .attr('cy', function(d) { return d.y; });
+
+      link.attr('x1', function(d) { return d.source.x; })
+          .attr('y1', function(d) { return d.source.y; })
+          .attr('x2', function(d) { return d.target.x; })
+          .attr('y2', function(d) { return d.target.y; });
+    }
   }
 };


### PR DESCRIPTION
 Got d3 to update without a re-render in a force-directed graph! Using fake data and setInterval currently.
The good news is that it does calculate the diff for us. We just have to pass in the updated value for nodes and links and preserve order by passing in a function that returns a unique ID for each node as the second argument for the `data()` method.
Also for a fraction of a second, some nodes appear at (0,0) (top left corner of the page) -- not sure if that is preventable but worth looking into as well.
Next step would be to draw with `<canvas>` instead and try using fake data that is even more similar to the form of data we would be passing in (maybe taking two or three snapshots of data and inserting it into this code)..