### PR TITLE
Storage callback to update visualization. Fixes #75.

### DIFF
--- a/js/lightbeam.js
+++ b/js/lightbeam.js
@@ -50,3 +50,6 @@ async function renderGraph() {
 
 window.onload = renderGraph;
 
+storeChild.register((data) => {
+  console.log(data);
+});

--- a/js/storeChild.js
+++ b/js/storeChild.js
@@ -1,5 +1,36 @@
 // eslint-disable-next-line no-unused-vars
 const storeChild = {
+  callbacks: new Set(),
+
+  init() {
+    browser.runtime.onMessage.addListener((m) => {
+      this.messageHandler(m);
+    });
+  },
+
+  update(data) {
+    this.callbacks.forEach((callback) => {
+      callback(data);
+    });
+  },
+
+  register(callback) {
+    this.callbacks.add(callback);
+  },
+
+  messageHandler(m) {
+    if (m.type !== 'storeChildCall') {
+      return;
+    }
+
+    const publicMethods = ['update'];
+
+    if (publicMethods.includes(m['method'])) {
+      const args = m.args;
+      return this[m['method']](...args);
+    }
+  },
+
   async getAll() {
     return await this.parentMessage('getAll');
   },
@@ -12,3 +43,5 @@ const storeChild = {
     });
   }
 };
+
+storeChild.init();


### PR DESCRIPTION
WIP. Using `runtime.onMessage` and `runtime.sendMessage` to pass data to `lightbeam.js` when `store.setFirstParty` or `store.setThirdParty` is called. Currently the data is pretty ugly and logs to the console. Need to ensure that each first and third party request only pings the page scripts once per new node/link.