### PR TITLE
Bug fix: Improve graph forces

### DIFF
--- a/js/viz.js
+++ b/js/viz.js
@@ -49,37 +49,17 @@ const viz = {
 
   tick() {
     this.simulation.stop();
-
     this.allCircles
-      .attr('cx', function(d) {
-        return d.x;
-      })
-      .attr('cy', function(d) {
-        return d.y;
-      });
-
+      .attr('cx', (d) => d.x)
+      .attr('cy', (d) => d.y);
     this.allLabels
-      .attr('x', function(d) {
-        return d.x;
-      })
-      .attr('y', function(d) {
-        return d.y;
-      });
-
+      .attr('x', (d) => d.x)
+      .attr('y', (d) => d.y);
     this.allLines
-      .attr('x1', function(d) {
-        return d.source.x;
-      })
-      .attr('y1', function(d) {
-        return d.source.y;
-      })
-      .attr('x2', function(d) {
-        return d.target.x;
-      })
-      .attr('y2', function(d) {
-        return d.target.y;
-      });
-
+      .attr('x1', (d) => d.source.x)
+      .attr('y1', (d) => d.source.y)
+      .attr('x2', (d) => d.target.x)
+      .attr('y2', (d) => d.target.y);
     this.simulation.tick();
   },
 
@@ -88,9 +68,7 @@ const viz = {
     this.tick();
 
     // determine which nodes to keep, remove and add: the update selection
-    this.allCircles = this.allCircles.data(nodes, function(d) {
-      return d.hostname;
-    });
+    this.allCircles = this.allCircles.data(nodes, (d) => d.hostname);
 
     // remove old nodes: the exit selection
     const oldNodes = this.allCircles.exit();
@@ -105,9 +83,7 @@ const viz = {
 
     this.allCircles = newNodes.merge(this.allCircles);
 
-    this.allLabels = this.allLabels.data(nodes, function(d) {
-      return d.hostname;
-    });
+    this.allLabels = this.allLabels.data(nodes, (d) => d.hostname);
 
     const oldText = this.allLabels.exit();
     oldText.remove();
@@ -115,18 +91,14 @@ const viz = {
     let newText = this.allLabels.enter();
     newText = newText.append('text');
     newText.attr('class', 'textLabel')
-    .text( function (d) {
-      return d.hostname;
-    })
+    .text((d) => d.hostname)
     .attr('fill', 'white');
 
     this.allLabels = newText.merge(this.allLabels);
 
     // determine which links to keep, remove and add, the update selection
     this.allLines = this.allLines
-      .data(links, function(d) {
-        return `${d.source.hostname}-${d.target.hostname}`;
-      });
+      .data(links, (d) => `${d.source.hostname}-${d.target.hostname}`);
 
     // remove old links
     const oldLinks = this.allLines.exit();

--- a/js/viz.js
+++ b/js/viz.js
@@ -18,16 +18,19 @@ const viz = {
 
   simulateForce(nodes, links) {
     const { width, height } = this.getDimensions();
-    const simulation = d3.forceSimulation(nodes);
     const linkForce = d3.forceLink(links);
+    let simulation;
 
-    linkForce.id(function (d) {
-      return d.hostname;
-    });
-    linkForce.distance(50);
+    if (!this.simulation) {
+      simulation = d3.forceSimulation(nodes);
+    } else {
+      simulation = this.simulation;
+      simulation.nodes(nodes);
+    }
 
-    simulation.force('charge', d3.forceManyBody());
+    linkForce.id((d) => d.hostname);
     simulation.force('link', linkForce);
+    simulation.force('charge', d3.forceManyBody());
     simulation.force('center', d3.forceCenter(width/2, height/2));
     simulation.alphaTarget(1);
 
@@ -36,8 +39,7 @@ const viz = {
 
   getDimensions() {
     const visualization = document.getElementById('visualization');
-    const width = visualization.getBoundingClientRect().width;
-    const height = visualization.getBoundingClientRect().height;
+    const { width, height } = visualization.getBoundingClientRect();
 
     return {
       width,
@@ -84,6 +86,7 @@ const viz = {
   update(nodes, links) {
     this.simulation = this.simulateForce(nodes, links);
     this.tick();
+
     // determine which nodes to keep, remove and add: the update selection
     this.allCircles = this.allCircles.data(nodes, function(d) {
       return d.hostname;


### PR DESCRIPTION
Bug: #76 

I have fixed the following bugs:

- the spinning graph
- sub-graphs going out of view
  * Even though the sub-graph goes out of view, when the update is complete the graph is pulled back and displayed in the main display area. The graph out of view still needs to be fixed, but this PR is an improvement to the old code

Before:

![graph-spin](https://user-images.githubusercontent.com/8022693/27933149-9c40dc50-62a0-11e7-99b7-58f57114cba9.gif)

After:

![graph-no-spin](https://user-images.githubusercontent.com/8022693/27933170-a3aca12c-62a0-11e7-9e36-7fb146216b60.gif)

Before:

![graph-out](https://user-images.githubusercontent.com/8022693/27936676-3c5919f8-62b2-11e7-8167-46718d23a4ee.gif)

After:

![graph-in](https://user-images.githubusercontent.com/8022693/27936696-6e81639a-62b2-11e7-942f-28997c79ec67.gif)








