### PR TITLE
D3 on canvas

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -290,6 +290,11 @@ input[type="checkbox"] {
   color: var(--secondary-text-color);
 }
 
+#visualization {
+  width: 500px;
+  height: 400px;
+}
+
 .info-panel-controls {
   display: flex;
   flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
             <h2><span id="view">Graph</span> View</h2>
             <!-- @todo display list or graph view, update view based on filter and controls -->
             <!-- @todo remove the hard-coded width, height values -->
-            <svg id="visualization" width="100%" height="100%"></svg>
+            <div id="visualization"></div>
           </div>
           <div class="info-panel-controls">
             <!-- @todo check purpose of website icon -->

--- a/js/viz.js
+++ b/js/viz.js
@@ -141,11 +141,7 @@ const viz = {
   },
 
   virtualDom(type, elements) {
-    this[type] = this[type].data(elements, (d) => (
-      type === 'lines'
-      ? `${d.source.hostname}-${d.target.hostname}`
-      : d
-    ));
+    this[type] = this[type].data(elements, (d) => d);
 
     this[type].exit().remove();
 

--- a/js/viz.js
+++ b/js/viz.js
@@ -75,7 +75,7 @@ const viz = {
     this.context.clearRect(0, 0, this.width, this.height);
     this.context.save();
     this.drawNodes();
-    this.drawLabels();
+    // this.drawLabels();
     this.drawLinks();
     this.context.restore();
   },
@@ -92,15 +92,15 @@ const viz = {
       }
       this.context.closePath();
       this.context.fill();
+
+      this.drawLabel(d.hostname, d.x, d.y);
     }
   },
 
-  drawLabels() {
+  drawLabel(title, x, y) {
     this.context.fillStyle = 'white';
     this.context.beginPath();
-    for (const d of this.nodes) {
-      this.context.fillText(d.hostname, d.x, d.y);
-    }
+    this.context.fillText(title, x, y);
     this.context.closePath();
     this.context.fill();
   },

--- a/js/viz.js
+++ b/js/viz.js
@@ -89,8 +89,6 @@ const viz = {
   drawOnCanvas() {
     this.context.clearRect(0, 0, this.width, this.height);
     this.context.save();
-    this.context.strokeStyle = '#ccc';
-    this.context.fillStyle = 'steelblue';
     this.drawNodes();
     this.drawLabels();
     this.drawLinks();
@@ -98,18 +96,28 @@ const viz = {
   },
 
   drawNodes() {
-    this.context.beginPath();
     this.circles.each((d) => {
+      this.context.beginPath();
       this.context.moveTo(d.x, d.y);
       this.context.arc(d.x, d.y, 4.5, 0, 2 * Math.PI);
+      if (d.firstParty) {
+        this.context.fillStyle = 'red';
+      } else {
+        this.context.fillStyle = 'blue';
+      }
+      this.context.closePath();
+      this.context.fill();
     });
-    this.context.fill();
   },
 
   drawLabels() {
+    this.context.fillStyle = 'white';
+    this.context.beginPath();
     this.labels.each((d) => {
       this.context.fillText(d.hostname, d.x, d.y);
     });
+    this.context.closePath();
+    this.context.fill();
   },
 
   showLabel(index) {
@@ -128,6 +136,8 @@ const viz = {
       this.context.moveTo(d.source.x, d.source.y);
       this.context.lineTo(d.target.x, d.target.y);
     });
+    this.context.closePath();
+    this.context.strokeStyle = '#ccc';
     this.context.stroke();
   },
 

--- a/js/viz.js
+++ b/js/viz.js
@@ -1,8 +1,5 @@
 // eslint-disable-next-line no-unused-vars
 const viz = {
-  radius: 5,
-  textLabelGutter: 5,
-
   init(nodes, links) {
     const { width, height } = this.getDimensions('visualization');
 
@@ -23,12 +20,10 @@ const viz = {
 
   simulate() {
     this.simulation = this.simulateForce();
-    this.updatePositions();
     this.simulation.tick();
   },
 
   simulateForce() {
-    const linkForce = d3.forceLink(this.links);
     let simulation;
 
     if (!this.simulation) {
@@ -39,11 +34,17 @@ const viz = {
       simulation.nodes(this.nodes);
     }
 
+    const linkForce = d3.forceLink(this.links);
     linkForce.id((d) => d.hostname);
     linkForce.distance(100);
-    simulation.force('charge', d3.forceManyBody());
     simulation.force('link', linkForce);
-    simulation.force('center', d3.forceCenter(this.width/2, this.height/2));
+
+    const centerForce = d3.forceCenter(this.width/2, this.height/2);
+    centerForce.x(this.width/2);
+    centerForce.y(this.height/2);
+    simulation.force('center', centerForce);
+
+    simulation.force('charge', d3.forceManyBody());
     simulation.force('collide', d3.forceCollide(5));
     simulation.alphaTarget(1);
 
@@ -68,19 +69,6 @@ const viz = {
       width,
       height
     };
-  },
-
-  updatePositions() {
-    for (const d of this.nodes) {
-      d.x = d.x + this.radius + this.textLabelGutter;
-      d.y = d.y + this.radius + this.textLabelGutter;
-    }
-    for (const d of this.links) {
-      d.x1 = d.source.x;
-      d.y1 = d.source.y;
-      d.x2 = d.target.x;
-      d.y2 = d.target.y;
-    }
   },
 
   drawOnCanvas() {

--- a/js/viz.js
+++ b/js/viz.js
@@ -15,7 +15,6 @@ const viz = {
     this.labels = custom.selectAll('custom.label');
     this.lines = custom.selectAll('custom.line');
 
-    this.simulate(nodes, links);
     this.draw(nodes, links);
   },
 
@@ -142,7 +141,11 @@ const viz = {
   },
 
   virtualDom(type, elements) {
-    this[type] = this[type].data(elements, (d) => d);
+    this[type] = this[type].data(elements, (d) => (
+      type === 'lines'
+      ? `${d.source.hostname}-${d.target.hostname}`
+      : d
+    ));
 
     this[type].exit().remove();
 
@@ -160,6 +163,7 @@ const viz = {
   },
 
   draw(nodes, links) {
+    this.simulate(nodes, links);
     this.createVirtualDom(nodes, links);
     this.drawOnCanvas();
     this.simulate(nodes, links);


### PR DESCRIPTION
Fixes #90 

Canvas based solution for the visualisations.

PR started by following this blog: https://bocoup.com/blog/d3js-and-canvas
As pointed out in this blog, the idea is to create custom elements which aren't loaded into the DOM, but are in memory (virtual dom) and then repainting the canvas. Doing so, we get to use D3's core algorithms (force layout in our case).

We don't use dummy elements anymore. D3's force layout algorithm is used and nodes, links are painted on the canvas.