### PR TITLE
Hide unimplemented UI elements.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -457,3 +457,11 @@ footer {
     grid-column-start: 1;
   }
 }
+
+.unimplemented {
+  visibility: hidden;
+}
+
+.unimplemented.list {
+  display: none;
+}

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       <div class="toggle-menu">
         <!-- @todo add click to toggle view between graph and list, highlighting active view -->
         <button class="active graph">Graph</button>
-        <button class="list">List</button>
+        <button class="list unimplemented">List</button>
       </div>
       <h2>Data</h2>
       <div>
@@ -36,9 +36,6 @@
       <div class="nav-links">
         <!-- @todo confirm feedback URL -->
         <a class="thumbs-up" href="mailto:lightbeam-feedback@mozilla.org">Give Us Feedback</a>
-        <br>
-        <!-- @todo confirm uninstall URL -->
-        <a href="https://support.mozilla.org/en-US/kb/disable-or-remove-add-ons">Uninstall Lightbeam</a>
       </div>
     </nav>
     </aside>
@@ -68,7 +65,7 @@
           </div>
         </dl>
         <!-- @todo add tracking protection and toggle functionality -->
-        <div class="tracking-protection">
+        <div class="tracking-protection unimplemented">
           <label for="tracking-protection-control">Tracking Protection</label>
           <div class="toggle-switch">
           <!-- @todo couple checkbox status (checked/unchecked) with toggle status -->
@@ -89,7 +86,7 @@
           <!-- @todo display list or graph view, update view based on filter and controls -->
           <!-- @todo remove the hard-coded width, height values -->
         </div>
-        <div class="vis-controls info-panel-controls">
+        <div class="vis-controls info-panel-controls unimplemented">
           <!-- @todo check purpose of website icon -->
           <button class="info-panel website"></button>
           <!-- @todo add help sidebar -->
@@ -102,7 +99,7 @@
         </div>
       </section>
       <footer>
-        <div class="footer-toggle">
+        <div class="footer-toggle unimplemented">
           <div class="footer-heading">
             <h2>Toggle Controls</h2>
           </div>
@@ -116,7 +113,7 @@
             <button class="connections active">Connections</button>
           </div>
         </div>
-        <div class="footer-filter">
+        <div class="footer-filter unimplemented">
           <div class="footer-heading">
             <h2>Filter</h2>
             <!-- @todo add click for hide to toggle filter menu-->


### PR DESCRIPTION
Added the `.unimplemented` class to unimplemented UI elements.

This PR is related to Issue #129 , where we discuss removing unimplemented features until they are ready.

I also removed the 'Uninstall Lightbeam' link.