### PR TITLE
Provides consistent lastRequestTime

### DIFF
--- a/src/js/store.js
+++ b/src/js/store.js
@@ -262,9 +262,8 @@ const store = {
           // store first and last request times for clearing data every X days
           if (!('firstRequestTime' in website)) {
             website.firstRequestTime = value;
-          } else {
-            website.lastRequestTime = value;
           }
+          website.lastRequestTime = value;
           break;
         case 'isVisible':
           if ('isVisible' in website


### PR DESCRIPTION
Currently lastRequestTime is not set for newly added websites, meaning that some items in the database do not have a lastRequestTime field.